### PR TITLE
Add standard library urllib

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Standard library
 - [socket](#socket)
 - [subprocess](#subprocess)
 - [telnetlib](#telnetlib)
+- [urllib](#urllib)
 
 PyPI
 
@@ -124,6 +125,15 @@ Telnet(host, timeout=1)
 ```
 
 Raises `socket.timeout`
+
+### urllib
+
+```python
+req = Request(url)
+urlopen(req, timeout=1)
+```
+
+Raises `urllib.error.URLError`
 
 ## PyPI
 

--- a/tests/test_urllib.py
+++ b/tests/test_urllib.py
@@ -1,0 +1,10 @@
+from .conftest import TestTimeouts
+from urllib.request import Request, urlopen
+from urllib.error import URLError
+
+
+class TestRequests(TestTimeouts):
+    def test_urlopen(self):
+        with self.raises(URLError):
+            req = Request(self.connect_url())
+            urlopen(req, timeout=1)


### PR DESCRIPTION
Hi, thanks for putting this repository together this is adding an entry for the Python standard library `urllib.request` Request objects: https://docs.python.org/3/library/urllib.request.html#module-urllib.request

(not be confused with `urllib3` or the `requests` libraries :))